### PR TITLE
Query result to be string instead of a list.

### DIFF
--- a/query-services/repository/api/repository.py
+++ b/query-services/repository/api/repository.py
@@ -25,7 +25,7 @@ class Repository:
         result = r.json()
         for item in result["items"]:
             data.append("repo:%s" % item['full_name'])
-        return json.dumps(dict(query=data)), 200
+        return json.dumps(dict(query=" ".join(data))), 200
 		
 
 


### PR DESCRIPTION
{"query": "repo:freeCodeCamp/freeCodeCamp repo:twbs/bootstrap repo:EbookFoundation/free-programming-books repo:facebook/react repo:d3/d3 repo:tensorflow/tensorflow repo:getify/You-Dont-Know-JS repo:sindresorhus/awesome repo:vuejs/vue repo:robbyrussell/oh-my-zsh repo:airbnb/javascript repo:angular/angular.js repo:github/gitignore repo:facebook/react-native repo:FortAwesome/Font-Awesome repo:electron/electron repo:torvalds/linux repo:jwasham/coding-interview-university repo:jquery/jquery repo:moby/moby repo:daneden/animate.css repo:apple/swift repo:atom/atom repo:nodejs/node repo:meteor/meteor repo:h5bp/html5-boilerplate repo:vinta/awesome-python repo:rails/rails repo:Semantic-Org/Semantic-UI repo:nodejs/node-v0.x-archive"}