### PR TITLE
Linked language and pain service with data service

### DIFF
--- a/clarity-seed/src/app/preferences/preferences.component.html
+++ b/clarity-seed/src/app/preferences/preferences.component.html
@@ -20,6 +20,14 @@
                     </div>
                 </div>
                 <div class="form-group">
+                    <label for="commentScope">Pain:</label>
+                    <div class="select">
+                        <select class="capitalize" [(ngModel)]="query['pain']" id="state" name="query.pain">
+                            <option *ngFor="let painLevel of painLevels" [value]="painLevel.value">{{painLevel.type}}</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="form-group">
                     <label for="language">Language</label>
                     <input type="text" id="language" placeholder="Enter Language..." size="45" name="query.language" [(ngModel)]="query['language']">
                 </div>

--- a/clarity-seed/src/app/preferences/preferences.component.ts
+++ b/clarity-seed/src/app/preferences/preferences.component.ts
@@ -23,6 +23,10 @@ export class PreferencesComponent implements OnInit, OnDestroy {
         { 'type': 'Title and body', 'value': 'body' },
         { 'type': 'Comments', 'value': 'comments' }
     ];
+    painLevels = [
+        { 'type': 'Really painful', 'value': 'high' },
+        { 'type': 'Some pain', 'value': 'medium' }
+    ];
 
     reactionTypes = [
         { 'type': 'Most reactions', 'value': 'reactions' },
@@ -42,7 +46,6 @@ export class PreferencesComponent implements OnInit, OnDestroy {
 
     ngOnInit(): void {
         // now linked with the running language service
-        this.dataService.getIssueFromService("java").subscribe(res => { console.log(res['_body']); });
         this.query = this.sharedService.query;
     }
 
@@ -52,8 +55,14 @@ export class PreferencesComponent implements OnInit, OnDestroy {
     }
 
     search() {
-        // TODO: match all or match any?
+        this.dataService.getQueryStrFromPainService(this.query['pain']).subscribe(res => {
+            this.query['painQueryStr'] = res.json()['query'];
+        });
+        this.dataService.getQueryStrFromLanguageService(this.query['language']).subscribe(res => {
+            this.query['languageQueryStr'] = res.json()['language'];
+        });
         this.sharedService.query = this.query;
-        this.router.navigate(['/profile']);
+        // don't navigate here - give a chance the user to change something
+        // this.router.navigate(['/profile']);
     }
 }

--- a/clarity-seed/src/app/profile/profile.component.ts
+++ b/clarity-seed/src/app/profile/profile.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, OnInit, ChangeDetectorRef } from "@angular/core";
 import { DataService } from "../services/data.service";
 import { SharedService } from "../services/shared.service";
 
@@ -19,7 +19,8 @@ export class ProfileComponent implements OnInit {
     userIssues = [];
 
     constructor(private dataService: DataService,
-                private sharedService: SharedService) { }
+                private sharedService: SharedService,
+                private ref: ChangeDetectorRef) { }
 
     ngOnInit(): void {
         this.dataService.getRepositories().
@@ -38,6 +39,7 @@ export class ProfileComponent implements OnInit {
                 this.userIssues = res.json()['items'];
                 // console.log(this.userIssues);
                 this.loadingUserIssues = false;
+                this.ref.detectChanges();
             }, (err) => {
                 console.log(err);
                 this.loadingUserIssues = false;

--- a/clarity-seed/src/app/services/data.service.ts
+++ b/clarity-seed/src/app/services/data.service.ts
@@ -12,7 +12,7 @@ export class DataService {
   }
 
   getRepositories() {
-     return this.doGet(ENDPOINT_API + '/repositories');
+    return this.doGet(ENDPOINT_API + '/repositories');
     //return this.doGet("/repos/angular/angular.js/issues?state=open&sort=updated&page=1&per_page=100&assignee=*");
   }
 
@@ -26,13 +26,17 @@ export class DataService {
     return this.doGet(issuesUrl);
   }
 
-  getIssuesForLanguage(language: string ) { //array of languages?
-    let issuesUrl = ENDPOINT_API + '/search/issues?q=language:' + language +"+state:open";
+  getIssuesForLanguage(language: string) { //array of languages?
+    let issuesUrl = ENDPOINT_API + '/search/issues?q=language:' + language + "+state:open";
     return this.doGet(issuesUrl);
   }
 
-  getIssueFromService(seed: string) {
+  getQueryStrFromLanguageService(seed: string) {
     return this.doGet("http://localhost:5001/v1/language?seed=" + seed);
+  }
+
+  getQueryStrFromPainService(seed: string) {
+    return this.doGet("http://localhost:5003/v1/pain?seed=" + seed);
   }
 
   getIssuesWithQuery(query: string) {
@@ -41,7 +45,7 @@ export class DataService {
   }
 
   getIssueDetails(issueDetailsUrl: string) {
-     return this.doGet(issueDetailsUrl);
+    return this.doGet(issueDetailsUrl);
   }
 
   private doPost(url: string, body?: any): Observable<any> {
@@ -58,7 +62,7 @@ export class DataService {
     }
 
     return this.http.get(url, reqOptions);
-     //  .map(res => res.json());
+    //  .map(res => res.json());
   }
 
   private doPut(url: string, body: any): Observable<any> {
@@ -84,23 +88,26 @@ export class DataService {
   }
 
   public buildQuery(queryObj: any) {
-    // type: string, language: string, scope: string, isPublic: string,
-    // author: string, state: string, comments: string, sort: string): string {
     let query = '';
-    if (queryObj['type']) { query += 'type:' + queryObj['type'] + ' ';}
-    if (queryObj['state']) { query += 'state:' + queryObj['state'] + ' ';}
-    if (queryObj['language']) { query += 'language:' + queryObj['language'] + ' ';}
-    if (queryObj['scope']) { query += 'in:' + queryObj['scope']; + ' ';}
-    if (queryObj['author']) { query += 'author:' + queryObj['author'] + ' ';}
+    if (queryObj['type']) { query += 'type:' + queryObj['type'] + ' '; }
+    if (queryObj['state']) { query += 'state:' + queryObj['state'] + ' '; }
+    if (queryObj['languageQueryStr']) {
+      query += queryObj['languageQueryStr'] + ' ';
+    } else { // fallback to direct query appending
+      if (queryObj['language']) { query += 'language:' + queryObj['language'] + ' '; }
+    }
+    if (queryObj['scope']) { query += 'in:' + queryObj['scope']; + ' '; }
+    if (queryObj['author']) { query += 'author:' + queryObj['author'] + ' '; }
     if (queryObj['comment']) {
       let escapedComment = queryObj['comment'].replace(/"/g, '\\"');
       query += '"' + escapedComment + '"' + ' ';
     }
-    if (queryObj['commentsCount']) { query += 'comments:' + queryObj['commentsCount'] + ' ';} // comments:>500 or 500..1000
-    if (queryObj['sort']) { query += 'sort:' + queryObj['sort'] + ' ';}
-    if (queryObj['stars']) { query += 'stars:' + queryObj['stars'] + ' ';}
+    if (queryObj['commentsCount']) { query += 'comments:' + queryObj['commentsCount'] + ' '; } // comments:>500 or 500..1000
+    if (queryObj['sort']) { query += 'sort:' + queryObj['sort'] + ' '; }
+    if (queryObj['stars']) { query += 'stars:' + queryObj['stars'] + ' '; }
+    if (queryObj['painQueryStr']) { query += queryObj['painQueryStr'] + ' '; }
 
-    console.log("build query: " + query);
+    console.log(">>> Build query: " + query);
     return query;
   }
 }

--- a/query-services/pain/api/pain.py
+++ b/query-services/pain/api/pain.py
@@ -6,7 +6,7 @@ class Pain:
         if seed == "high":
             query = "comments:>30 critical in:comments"
         elif seed == "medium":
-            query = "comments:5:30 hurts in:comments"
+            query = "comments:5..30 hurts in:comments"
         else:
             query = ""
 


### PR DESCRIPTION
Now using the real queryString from the running services (ports 5001 and
5003).
If something fails from the service we fallback to direct query
appending to the query string.

Also fixed pain.py service bug - comments range were seperated with ':'
and should be '..'

Also fixed a bug in Clarity UI - calling detect changes when the data is
retrieved.